### PR TITLE
Allow user to customise schemes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,8 @@ Usage
         'license': {
             'name': 'BSD',
             'url': 'https://github.com/pyeve/eve-swagger/blob/master/LICENSE',
-        }
+        },
+        schemes: ['http', 'https'],
     }
 
     # optional. Will use flask.request.host if missing.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Eve-Swagger |latest-version|
 ============================
 
-|build-status| |python-support| 
+|build-status| |python-support|
 
 Swagger_ extension for Eve_ powered RESTful APIs.
 
@@ -29,7 +29,7 @@ Usage
             'name': 'BSD',
             'url': 'https://github.com/pyeve/eve-swagger/blob/master/LICENSE',
         },
-        schemes: ['http', 'https'],
+        'schemes': ['http', 'https'],
     }
 
     # optional. Will use flask.request.host if missing.
@@ -99,7 +99,7 @@ As an example:
         },
     }
     ...
-    
+
 **NOTE**: If you do use that feature make sure that the ``TRANSPARENT_SCHEMA_RULES``
 in your ``settings.py`` is also turned ON, otherwise you will get complains from the
 Cerberus library about "unknown field 'description' for field [yourFieldName]"

--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -47,6 +47,10 @@ def base_path():
 
 
 def schemes():
+    cfg = app.config[eve_swagger.INFO]
+    if hasattr(cfg, 'schemes'):
+        return cfg['schemes']
+
     scheme = request.url.split(':')[0]
     return [scheme] if scheme in ['http', 'https', 'ws', 'wss'] else None
 

--- a/eve_swagger/tests/tests.py
+++ b/eve_swagger/tests/tests.py
@@ -257,6 +257,11 @@ class TestEveSwagger(TestBase):
         self.assertIn('200', person['put']['responses'])
         self.assertIn('204', person['delete']['responses'])
 
+    def test_schemes_override(self):
+        self.app.config['SWAGGER_INFO']['schemes'] = ['https']
+        r = self.test_client.get('/api-docs')
+        self.assertEqual(r.status_code, 200)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/eve_swagger/validation.py
+++ b/eve_swagger/validation.py
@@ -45,6 +45,12 @@ def validate_info():
                 'url': {'type': 'string', 'validator': _validate_url}
             }
         },
+        'schemes': {
+            'type': 'list',
+            'schema': {
+                'type': 'string'
+            }
+        }
     }
     if eve_swagger.INFO not in app.config:
         raise ConfigException('%s setting is required in Eve configuration.' %


### PR DESCRIPTION
If the user provides a 'schemes' configuration value use that instead of auto-discovering the value. This is useful in the scenario where Eve is running on http behind a proxy running https, so auto-discovery would yield the wrong value.