### PR TITLE
fix wrong schemes override checking

### DIFF
--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -48,7 +48,7 @@ def base_path():
 
 def schemes():
     cfg = app.config[eve_swagger.INFO]
-    if hasattr(cfg, 'schemes'):
+    if 'schemes' in cfg:
         return cfg['schemes']
 
     scheme = request.url.split(':')[0]

--- a/eve_swagger/tests/tests.py
+++ b/eve_swagger/tests/tests.py
@@ -281,6 +281,9 @@ class TestEveSwagger(TestBase):
         self.app.config['SWAGGER_INFO']['schemes'] = ['https']
         r = self.test_client.get('/api-docs')
         self.assertEqual(r.status_code, 200)
+        s = r.get_data().decode('utf-8')
+        d = json.loads(s)
+        self.assertEqual(d.get('schemes'), ['https'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Override `schemes` in `SWAGGER_INFO` does not  work, because the `schemes()` function is checking it wrongly:
```
def schemes():
    cfg = app.config[eve_swagger.INFO]
    if hasattr(cfg, 'schemes'):
        return cfg['schemes']

    scheme = request.url.split(':')[0]
return [scheme] if scheme in ['http', 'https', 'ws', 'wss'] else None
```

`cfg` is a `dict`, it has no attribute `schemes`.

This PR fixes the issue by checking the `schemes` key actually exists.