### PR TITLE
Fix bug where code expects obj instead of dict

### DIFF
--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -48,7 +48,7 @@ def base_path():
 
 def schemes():
     cfg = app.config[eve_swagger.INFO]
-    if hasattr(cfg, 'schemes'):
+    if 'schemes' in cfg:
         return cfg['schemes']
 
     scheme = request.url.split(':')[0]

--- a/eve_swagger/tests/tests.py
+++ b/eve_swagger/tests/tests.py
@@ -280,6 +280,7 @@ class TestEveSwagger(TestBase):
     def test_schemes_override(self):
         self.app.config['SWAGGER_INFO']['schemes'] = ['https']
         r = self.test_client.get('/api-docs')
+        self.assertEqual(json.loads(r.data)['schemes'], ['https'])
         self.assertEqual(r.status_code, 200)
 
 


### PR DESCRIPTION
- cfg is a dict not object so use 'in' instead of hasattr

(Not sure how this got through previously. I've enhanced the test as well to check the returned value is correct)