### PR TITLE
add nullable property

### DIFF
--- a/eve_swagger/definitions.py
+++ b/eve_swagger/definitions.py
@@ -127,6 +127,9 @@ def _field_props(rules, dr_sources, prefix):
 
     if 'regex' in rules:
         resp['pattern'] = rules['regex']
+        
+    if 'nullable' in rules:
+        resp['nullable'] = rules['nullable']
 
     type = map.get(eve_type, (eve_type,))
 


### PR DESCRIPTION
So far, the `nullable` property is not reported in the schema. However, [Version 3.0](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0-rc0/versions/3.0.md) of the OpenAPI specifications already include this property in the same form as known from eve/cerberus.
This PR includes the property into the reported schema.