### PR TITLE
Add resource 'example' field to override automatic schema generation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -213,6 +213,35 @@ your own validator.
 
     app = Eve(validator=MyValidator)
 
+Example resources on the docs
+-----------------------------
+
+Like a description, an example can be added to a resource.
+
+.. code-block:: python
+
+    ...
+    'sub_resource': {
+        'description': 'A sub resource to test regex urls.',
+        'url': 'people/<regex("[a-f0-9]{24}"):personid>/related',
+        'example': {'subject': 'A sub_resource object example'},
+
+        'schema': {
+            'personid': {
+                'type': 'objectid',
+                'data_relation': {
+                    'resource': 'people',
+                    'field': '_id', },
+            },
+            'subject': {'type': 'string'},
+        }
+    },
+    ...
+
+The resource example overrides the example generated from the schema definition, and can be used to hide fields that are defined on the server side.
+The example is shown in the swagger ui in the parameters only.
+
+
 Copyright
 ---------
 Eve-Swagger is an open source project by `Nicola Iarocci`_.

--- a/eve_swagger/definitions.py
+++ b/eve_swagger/definitions.py
@@ -25,6 +25,8 @@ def definitions():
         definitions[title] = _object(rd, dr_sources)
         if 'description' in rd:
             definitions[title]['description'] = rd['description']
+        if 'example' in rd:
+            definitions[title]['example'] = rd['example']
 
     # add data_relation source fields to #/definitions/
     definitions.update(dr_sources)
@@ -38,7 +40,7 @@ def _object(rd, dr_sources):
         if rules.get('required') is True:
             required.append(field)
 
-        def_name = rd['item_title']+'_'+field
+        def_name = rd['item_title'] + '_' + field
         props[field] = _field_props(rules, dr_sources, def_name)
 
         if def_name in dr_sources:
@@ -56,7 +58,7 @@ def _object(rd, dr_sources):
                 # source of data_relation does not exist
                 continue
             title = app.config['DOMAIN'][dr['resource']]['item_title']
-            source_def_name = title+'_'+dr['field']
+            source_def_name = title + '_' + dr['field']
             props[field] = {
                 '$ref': '#/definitions/{0}'.format(source_def_name)
             }
@@ -225,7 +227,7 @@ def _get_dr_sources(schema):
                 # source of data_relation does not exist
                 continue
             title = app.config['DOMAIN'][dr['resource']]['item_title']
-            def_name = title+'_'+dr['field']
+            def_name = title + '_' + dr['field']
             dr_sources[def_name] = None
         elif 'schema' in rules:
             if rules.get('type') in 'dict':

--- a/eve_swagger/tests/test_settings.py
+++ b/eve_swagger/tests/test_settings.py
@@ -62,13 +62,17 @@ DOMAIN = {
     'sub_resource': {
         'description': 'A sub resource to test regex urls.',
         'url': 'people/<regex("[a-f0-9]{24}"):personid>/related',
-        'personid': {
-            'type': 'objectid',
-            'data_relation': {
-                'resource': 'people',
-                'field': '_id', },
-        },
-        'subject': {'type': 'string'},
+        'example': {'subject': 'A sub_resource object example'},
+
+        'schema': {
+            'personid': {
+                'type': 'objectid',
+                'data_relation': {
+                    'resource': 'people',
+                    'field': '_id', },
+            },
+            'subject': {'type': 'string'},
+        }
     },
     'disabled_resource': {
         'disable_documentation': True,

--- a/eve_swagger/tests/tests.py
+++ b/eve_swagger/tests/tests.py
@@ -299,6 +299,12 @@ class TestEveSwagger(TestBase):
         self.assertEqual('people/<personid>/related', url)
         self.assertEqual('people/<personid>/related', resource_title)
 
+    def test_resource_example(self):
+        doc = self.swagger_doc
+        item_title = self.domain['sub_resource']['item_title']
+
+        self.assertIn('example', doc['definitions'][item_title])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The resource's 'example' field is used in the examples provided in POST requests documentation. This is useful for instance if one wants to hide some properties from the examples since they are not set by the client.