### PR TITLE
Drop support for EOL Python 2.6, 3.3 and 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
 install:
   - pip install tox
 env:
-  - TOX_ENV=py26
   - TOX_ENV=py27
   - TOX_ENV=py33
   - TOX_ENV=py34

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ install:
   - pip install tox
 env:
   - TOX_ENV=py27
-  - TOX_ENV=py33
-  - TOX_ENV=py34
   - TOX_ENV=py35
     #- TOX_ENV=pypy
     #- TOX_ENV=pypy3

--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ Patches and Contributions
 - Aurelien Grenotton
 - Cuong Manh Le
 - Damien Aboss
+- Hugo van Kemenade
 - Jim Kennedy
 - Luis Fernando Gomes
 - Matthew Ellison

--- a/eve_swagger/__init__.py
+++ b/eve_swagger/__init__.py
@@ -7,10 +7,6 @@
     :copyright: (c) 2015 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 """
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict  # noqa: F401
 from .swagger import swagger, add_documentation  # noqa
 
 INFO = 'SWAGGER_INFO'

--- a/eve_swagger/definitions.py
+++ b/eve_swagger/definitions.py
@@ -7,9 +7,8 @@
     :copyright: (c) 2016 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 """
+from collections import OrderedDict
 from flask import current_app as app
-
-from eve_swagger import OrderedDict
 
 
 def definitions():

--- a/eve_swagger/definitions.py
+++ b/eve_swagger/definitions.py
@@ -62,7 +62,7 @@ def _object(rd, dr_sources):
             dr_sources[def_name] = OrderedDict(props[field])
 
             props[field] = {
-                '$ref': '#/components/schemas/{0}'.format(def_name)}
+                '$ref': '#/components/schemas/{}'.format(def_name)}
 
         if 'data_relation' in rules:
             # the current field is a copy of another field
@@ -73,7 +73,7 @@ def _object(rd, dr_sources):
             title = app.config['DOMAIN'][dr['resource']]['item_title']
             source_def_name = title + '_' + dr['field']
             props[field] = {
-                '$ref': '#/components/schemas/{0}'.format(source_def_name)
+                '$ref': '#/components/schemas/{}'.format(source_def_name)
             }
 
     field_def = {}

--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -88,7 +88,7 @@ def parameters():
 
             # copy description if necessary
             descr = descr or source_def.get('description')
-            descr = descr + ' (links to {0})'.format(source_def_name)
+            descr = descr + ' (links to {})'.format(source_def_name)
 
         p = OrderedDict()
         p['in'] = 'path'
@@ -160,7 +160,7 @@ def request_bodies():
 
         title = rd['item_title']
         rb = OrderedDict()
-        description = 'A {0} document.'.format(title)
+        description = 'A {} document.'.format(title)
         if(rd['bulk_enabled']):
             description = 'A {0} or list of {0} documents'.format(title)
 

--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -7,10 +7,10 @@
     :copyright: (c) 2015 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 """
+from collections import OrderedDict
 from flask import request, current_app as app
 
 import eve_swagger
-from eve_swagger import OrderedDict
 from .validation import validate_info
 from .paths import get_ref_schema
 

--- a/eve_swagger/paths.py
+++ b/eve_swagger/paths.py
@@ -8,11 +8,10 @@
 """
 import re
 
+from collections import OrderedDict
 from textwrap import dedent
 
 from flask import current_app as app
-
-from eve_swagger import OrderedDict
 
 
 def paths():

--- a/eve_swagger/paths.py
+++ b/eve_swagger/paths.py
@@ -38,7 +38,7 @@ def paths():
         methods = rd['item_methods']
         if methods:
             item_id = '%sId' % rd['item_title'].lower()
-            url = '/%s/{%s}' % (rd['url'], item_id)
+            url = '/{}/{{{}}}'.format(rd['url'], item_id)
             paths[url] = _item(resource, rd, methods)
 
     return paths
@@ -147,7 +147,7 @@ def post_response(rd):
         if rd['bulk_enabled']:
             prefix += 'or more '
             title = rd['resource_title']
-        return '%s%s.' % (prefix, title)
+        return '{}{}.'.format(prefix, title)
 
     r = OrderedDict([
         ('summary', _get_description()),
@@ -267,7 +267,7 @@ def deleteitem_response(rd):
 
 
 def id_parameter(rd):
-    return {'$ref': '#/components/parameters/{0}_{1}'.
+    return {'$ref': '#/components/parameters/{}_{}'.
                     format(rd['item_title'], rd['item_lookup_field'])}
 
 

--- a/eve_swagger/swagger.py
+++ b/eve_swagger/swagger.py
@@ -8,12 +8,11 @@
     :license: BSD, see LICENSE for more details.
 """
 import re
-from collections import Mapping
+from collections import Mapping, OrderedDict
 from flask import Blueprint, jsonify, make_response, request, \
     current_app as app, render_template
 from functools import wraps
 
-from eve_swagger import OrderedDict
 from .definitions import definitions
 from .objects import info, servers, parameters, responses, request_bodies,\
     security_schemes, security, tags, external_docs, headers, links,\

--- a/eve_swagger/tests/__init__.py
+++ b/eve_swagger/tests/__init__.py
@@ -1,17 +1,12 @@
-import sys
 import os
 import json
+import unittest
 
 import eve
 import eve_swagger
 from pymongo import MongoClient
 from eve_swagger.tests.test_settings import MONGO_HOST, MONGO_PORT, \
     MONGO_USERNAME, MONGO_PASSWORD, MONGO_DBNAME
-
-if sys.version_info >= (2, 7):
-    import unittest  # noqa
-else:
-    import unittest2 as unittest  # noqa
 
 
 class TestBase(unittest.TestCase):

--- a/eve_swagger/tests/tests.py
+++ b/eve_swagger/tests/tests.py
@@ -45,7 +45,9 @@ class TestEveSwagger(TestBase):
         self.assertIn('paths', doc)
         self.assertIsInstance(doc['paths'], dict)
         self.assertIn('/' + url, doc['paths'])
-        self.assertIn('/%s/{%sId}' % (url, item_title.lower()), doc['paths'])
+        self.assertIn('/{}/{{{}Id}}'.format(
+            url, item_title.lower()), doc['paths']
+        )
 
     def test_components(self):
         doc = self.swagger_doc
@@ -63,8 +65,8 @@ class TestEveSwagger(TestBase):
         self.assertIn('properties', components['schemas'][item_title])
         self.assertEqual(
             set(components['schemas'][item_title]['properties'].keys()),
-            set(['name', 'job', 'email', 'position', '_id',
-                 'relations', 'location']))
+            {'name', 'job', 'email', 'position', '_id',
+             'relations', 'location'})
 
     def test_definitions_are_jsonschema(self):
         doc = self.swagger_doc
@@ -116,7 +118,7 @@ class TestEveSwagger(TestBase):
         lookup_field = self.domain['disabled_resource']['item_lookup_field']
 
         self.assertNotIn('/' + url, doc['paths'])
-        self.assertNotIn('/%s/{%sId}' % (url, item_title.lower()),
+        self.assertNotIn('/{}/{{{}Id}}'.format(url, item_title.lower()),
                          doc['paths'])
         self.assertNotIn(item_title, doc['components']['schemas'])
         self.assertNotIn(
@@ -163,7 +165,7 @@ class TestEveSwagger(TestBase):
 
         self.assertIn('description', par)
         self.assertEqual(
-            'foobar copied_field (links to {0}_job)'.format(people_it),
+            'foobar copied_field (links to {}_job)'.format(people_it),
             par['description'])
 
     def test_data_relation_copied_description(self):
@@ -175,14 +177,14 @@ class TestEveSwagger(TestBase):
 
         self.assertIn('description', par)
         self.assertEqual(
-            'the job of the person (links to {0}_job)'.format(people_it),
+            'the job of the person (links to {}_job)'.format(people_it),
             par['description'])
 
     def test_header_parameters(self):
         doc = self.swagger_doc
         url = self.domain['people']['url']
         item_title = self.domain['people']['item_title']
-        url = '/%s/{%sId}' % (url, item_title.lower())
+        url = '/{}/{{{}Id}}'.format(url, item_title.lower())
 
         parameters = doc['components']['parameters']
         self.assertIn('If-Match', parameters)
@@ -210,7 +212,7 @@ class TestEveSwagger(TestBase):
     def test_header_parameters_without_concurrency_control(self):
         url = self.domain['people']['url']
         item_title = self.domain['people']['item_title']
-        url = '/%s/{%sId}' % (url, item_title.lower())
+        url = '/{}/{{{}Id}}'.format(url, item_title.lower())
 
         def get_etag_param(doc):
             return doc['components']['parameters']['If-Match']
@@ -253,11 +255,11 @@ class TestEveSwagger(TestBase):
         self.assertIn('Access-Control-Allow-Headers', r.headers)
         self.assertEqual(
             set(r.headers['Access-Control-Allow-Headers'].split(', ')),
-            set(['Origin', 'X-Requested-With', 'Content-Type', 'Accept']))
+            {'Origin', 'X-Requested-With', 'Content-Type', 'Accept'})
         self.assertIn('Access-Control-Allow-Methods', r.headers)
         self.assertEqual(
             set(r.headers['Access-Control-Allow-Methods'].split(', ')),
-            set(['HEAD', 'OPTIONS', 'GET']))
+            {'HEAD', 'OPTIONS', 'GET'})
         self.assertIn('Access-Control-Max-Age', r.headers)
         self.assertEqual(r.headers['Access-Control-Max-Age'],
                          '2000')
@@ -276,7 +278,9 @@ class TestEveSwagger(TestBase):
             self.assertIn('tags', path_m)
             self.assertIn(item_title, path_m['tags'])
 
-        url = '/%s/{%sId}' % (self.domain['people']['url'], item_title.lower())
+        url = '/{}/{{{}Id}}'.format(
+            self.domain['people']['url'], item_title.lower()
+        )
         for m in ['get', 'patch', 'put', 'delete']:
             path_m = doc['paths'][url][m]
             self.assertIn('tags', path_m)
@@ -292,7 +296,7 @@ class TestEveSwagger(TestBase):
         self.assertIn('204', people['delete']['responses'])
 
         item_title = self.domain['people']['item_title']
-        person = doc['paths']['/%s/{%sId}' % (url, item_title.lower())]
+        person = doc['paths']['/{}/{{{}Id}}'.format(url, item_title.lower())]
         self.assertIn('200', person['get']['responses'])
         self.assertIn('200', person['patch']['responses'])
         self.assertIn('200', person['put']['responses'])

--- a/eve_swagger/validation.py
+++ b/eve_swagger/validation.py
@@ -57,7 +57,7 @@ def validate_info():
                               eve_swagger.INFO)
 
     if not v.validate(app.config[eve_swagger.INFO], schema):
-        raise ConfigException('%s is misconfigured: %s' % (
+        raise ConfigException('{} is misconfigured: {}'.format(
             eve_swagger.INFO, v.errors))
 
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
     packages=find_packages(),
     install_requires=read_file('requirements.txt'),
     keywords=['swagger', 'eve', 'rest', 'api'],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
@@ -57,7 +58,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     packages=find_packages(),
     install_requires=read_file('requirements.txt'),
     keywords=['swagger', 'eve', 'rest', 'api'],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
@@ -60,8 +60,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ skip_missing_interpreters = True
 envlist =
     flake8
     # pylint
-    py26
     py27
     py33
     py34
@@ -29,20 +28,4 @@ commands =
 [testenv]
 deps =
     jsonschema
-    py26: ordereddict
-    py26: unittest2
-
-[testenv:py26]
-commands = unit2 discover -v -s eve_swagger/tests
-
-[testenv:py27]
-commands = python -m unittest discover -v -s eve_swagger/tests
-
-[testenv:py33]
-commands = python -m unittest discover -v -s eve_swagger/tests
-
-[testenv:py34]
-commands = python -m unittest discover -v -s eve_swagger/tests
-
-[testenv:py35]
 commands = python -m unittest discover -v -s eve_swagger/tests

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,6 @@ envlist =
     flake8
     # pylint
     py27
-    py33
-    py34
     py35
 
 [testenv:flake8]


### PR DESCRIPTION
Fixes #80.

Here's the pip installs for eve-swagger from PyPI for March 2019:

| category | percent | downloads |
|----------|--------:|----------:|
|      2.7 |  54.76% |     1,122 |
|      3.6 |  29.53% |       605 |
|      3.7 |   6.20% |       127 |
| null     |   3.61% |        74 |
|      3.4 |   3.17% |        65 |
|      3.5 |   2.73% |        56 |
| Total    |         |     2,049 |

Source: `pypistats python_minor eve-swagger --last-month # pip install pypistats`
