### PR TITLE
Added option to remove example attribute inside parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,15 +122,14 @@ As an example:
     app = Eve(validator=MyValidator)
 
 
-**NOTE**: Swagger 2.0 may show errors about example attribute ("should NOT have additional properties"). You can disable generating example attribute by specifying:
+**NOTE**: Swagger 2.0 may show errors about example attribute ("should NOT have additional properties").
+ You can disable generating example attribute by specifying in the app.py:
 
 .. code-block:: python
 
     ...
     app.config['SWAGGER_EXAMPLE_FIELD_REMOVE'] = True
     ...
-    
-... in your app.py
 
 
 Disabling the documentation of a resource

--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,17 @@ As an example:
     app = Eve(validator=MyValidator)
 
 
+**NOTE**: Swagger 2.0 may show errors about example attribute ("should NOT have additional properties"). You can disable generating example attribute by specifying:
+
+.. code-block:: python
+
+    ...
+    app.config['SWAGGER_EXAMPLE_FIELD_REMOVE'] = True
+    ...
+    
+... in your app.py
+
+
 Disabling the documentation of a resource
 -----------------------------------------
 

--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -71,8 +71,8 @@ def parameters():
         eve_type = rd["schema"][lookup_field]["type"]
         descr = rd["schema"][lookup_field].get("description") or ""
         example = rd["schema"][lookup_field].get("example") or ""
-        if 'SWAGGER_EXAMPLE_FIELD_REMOVE' in app.config:
-            disable_example = app.config['SWAGGER_EXAMPLE_FIELD_REMOVE']
+        if "SWAGGER_EXAMPLE_FIELD_REMOVE" in app.config:
+            disable_example = app.config["SWAGGER_EXAMPLE_FIELD_REMOVE"]
         else:
             disable_example = False
         if "data_relation" in rd["schema"][lookup_field]:
@@ -100,7 +100,7 @@ def parameters():
         if disable_example is True:
             continue
         else:
-            p['example'] = example
+            p["example"] = example
 
         ptype = ""
         if eve_type == "objectid" or eve_type == "datetime":

--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -72,9 +72,9 @@ def parameters():
         descr = rd["schema"][lookup_field].get("description") or ""
         example = rd["schema"][lookup_field].get("example") or ""
         if 'SWAGGER_EXAMPLE_FIELD_REMOVE' in app.config:
-                disable_example = app.config['SWAGGER_EXAMPLE_FIELD_REMOVE']
+            disable_example = app.config['SWAGGER_EXAMPLE_FIELD_REMOVE']
         else:
-                disable_example = False
+            disable_example = False
         if "data_relation" in rd["schema"][lookup_field]:
             # the lookup field is a copy of another field
             dr = rd["schema"][lookup_field]["data_relation"]
@@ -98,9 +98,9 @@ def parameters():
         p["required"] = True
         p["description"] = descr
         if disable_example is True:
-                continue
+            continue
         else:
-                p['example'] = example
+            p['example'] = example
 
         ptype = ""
         if eve_type == "objectid" or eve_type == "datetime":

--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -97,7 +97,7 @@ def parameters():
         p["name"] = title.lower() + "Id"
         p["required"] = True
         p["description"] = descr
-        if disable_example == True:
+        if disable_example is True:
                 continue
         else:
                 p['example'] = example

--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -71,6 +71,10 @@ def parameters():
         eve_type = rd["schema"][lookup_field]["type"]
         descr = rd["schema"][lookup_field].get("description") or ""
         example = rd["schema"][lookup_field].get("example") or ""
+        if 'SWAGGER_EXAMPLE_FIELD_REMOVE' in app.config:
+                disable_example = app.config['SWAGGER_EXAMPLE_FIELD_REMOVE']
+        else:
+                disable_example = False
         if "data_relation" in rd["schema"][lookup_field]:
             # the lookup field is a copy of another field
             dr = rd["schema"][lookup_field]["data_relation"]
@@ -93,7 +97,10 @@ def parameters():
         p["name"] = title.lower() + "Id"
         p["required"] = True
         p["description"] = descr
-        p["example"] = example
+        if disable_example == True:
+                continue
+        else:
+                p['example'] = example
 
         ptype = ""
         if eve_type == "objectid" or eve_type == "datetime":


### PR DESCRIPTION
Fix for: https://github.com/pyeve/eve-swagger/issues/75

Simply added option to remove example attribute inside parameters by specifying:

app.config['SWAGGER_EXAMPLE_FIELD_REMOVE'] = True