### PR TITLE
Fix urlprefix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,9 +10,10 @@ Usage
 .. code-block:: python
 
     from eve import Eve
-    from eve_swagger import swagger, add_documentation
+    from eve_swagger import get_swagger_blueprint, add_documentation
 
     app = Eve()
+    swagger = get_swagger_blueprint()
     app.register_blueprint(swagger)
 
     # required. See http://swagger.io/specification/#infoObject for details.

--- a/eve_swagger/__init__.py
+++ b/eve_swagger/__init__.py
@@ -7,5 +7,5 @@
     :copyright: (c) 2015 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 """
-from .swagger import swagger, add_documentation  # noqa
+from .swagger import get_swagger_blueprint, add_documentation  # noqa
 from .definitions import INFO, HOST  # noqa

--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -44,8 +44,6 @@ def info():
 
 def servers():
     url = app.config.get(HOST) or "%s://%s" % (_get_scheme(), request.host)
-    if app.config["URL_PREFIX"]:
-        url = url + "/" + app.config["URL_PREFIX"]
     if app.config["API_VERSION"]:
         url = url + "/" + app.config["API_VERSION"]
     return [{"url": url}]
@@ -236,7 +234,6 @@ def headers():
 
 
 def security_schemes():
-    # from flask_oauthlib.provider import OAuth2Provider
     if "flask_oauthlib.provider" in sys.modules.keys():
         url = app.config.get(HOST) or request.host
         return {

--- a/eve_swagger/tests/__init__.py
+++ b/eve_swagger/tests/__init__.py
@@ -25,7 +25,9 @@ class TestBase(unittest.TestCase):
         self.settings = settings
         self.app = eve.Eve(settings=self.settings)
 
-        self.app.register_blueprint(eve_swagger.swagger)
+        swagger = eve_swagger.get_swagger_blueprint()
+
+        self.app.register_blueprint(swagger)
         self.app.config["SWAGGER_INFO"] = {
             "title": "Test eve-swagger",
             "version": "0.0.1",


### PR DESCRIPTION
The `URL_PREFIX` is not respected on this extension. Should be something as simple as providing it when registering the blueprint: 

`app.register_blueprint(swagger, url_prefix="/%s" % app.config["URL_PREFIX"])`

However this does not work as intended (not sure why). So, I propose changing the extension to be able to provide the `url_prefix` at the blueprint creation statement. Alternative suggestions are welcome.
`