### PR TITLE
add the URL_PREFIX to the swagger url if applicable

### DIFF
--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -44,6 +44,8 @@ def info():
 
 def servers():
     url = app.config.get(HOST) or "%s://%s" % (_get_scheme(), request.host)
+    if app.config["URL_PREFIX"]:
+        url = url + "/" + app.config["URL_PREFIX"]
     if app.config["API_VERSION"]:
         url = url + "/" + app.config["API_VERSION"]
     return [{"url": url}]


### PR DESCRIPTION
Prefix the swagger url with the URL_PREFIX if it is configured:
https://github.com/pyeve/eve-swagger/issues/94