### PR TITLE
Fix ABC import DeprecationWarning

### DIFF
--- a/eve_swagger/swagger.py
+++ b/eve_swagger/swagger.py
@@ -8,7 +8,13 @@
     :license: BSD, see LICENSE for more details.
 """
 import re
-from collections import Mapping, OrderedDict
+from collections import OrderedDict
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+
 from flask import (
     Blueprint,
     jsonify,


### PR DESCRIPTION
Fixed this DeprecationWarning:
```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
```