### PR TITLE
add projections query parameter

### DIFF
--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -145,6 +145,13 @@ def _query_parameters():
 
     r = OrderedDict()
     r["in"] = "query"
+    r["name"] = app.config["QUERY_PROJECTION"]
+    r["description"] = 'the projections query parameter (ex.: {"name": 1})'
+    r["schema"] = {"type": "string"}
+    params["query__projections"] = r
+    
+    r = OrderedDict()
+    r["in"] = "query"
     r["name"] = app.config["QUERY_SORT"]
     r["description"] = 'the sort query parameter (ex.: "city,-lastname")'
     r["schema"] = {"type": "string"}

--- a/eve_swagger/paths.py
+++ b/eve_swagger/paths.py
@@ -122,6 +122,7 @@ def get_ref_response(label):
 def get_ref_query():
     return [
         {"$ref": "#/components/parameters/query__where"},
+        {"$ref": "#/components/parameters/query__projections"},
         {"$ref": "#/components/parameters/query__sort"},
         {"$ref": "#/components/parameters/query__page"},
         {"$ref": "#/components/parameters/query__max_results"},


### PR DESCRIPTION
Not sure why this was left out in the original code, seems like a useful parameter. maybe it was added to eve after eve-swagger was made?