### PR TITLE
prepend url_prefix to spec_url

### DIFF
--- a/eve_swagger/swagger.py
+++ b/eve_swagger/swagger.py
@@ -58,7 +58,8 @@ def get_swagger_blueprint(url_prefix=""):
     @swagger.route("/docs")
     @_modify_response
     def index():
-        return render_template("index.html", spec_url="/api-docs")
+        spec_url = url_prefix.rstrip("/") + "/api-docs"
+        return render_template("index.html", spec_url=spec_url)
 
     return swagger
 


### PR DESCRIPTION
When using a non-empty url_prefix, the url_prefix should be added also to the spec_url:  

    spec_url = <url_prefix>/api-docs

Otherwise, /docs will try to fetch the json from /api-docs which now returns 404