### PR TITLE
Use correct spec_url when running in mod_wsgi

### DIFF
--- a/eve_swagger/swagger.py
+++ b/eve_swagger/swagger.py
@@ -22,6 +22,7 @@ from flask import (
     request,
     current_app as app,
     render_template,
+    url_for,
 )
 from functools import wraps
 
@@ -58,7 +59,7 @@ def get_swagger_blueprint(url_prefix=""):
     @swagger.route("/docs")
     @_modify_response
     def index():
-        spec_url = url_prefix.rstrip("/") + "/api-docs"
+        spec_url = url_for('eve_swagger.index_json')
         return render_template("index.html", spec_url=spec_url)
 
     return swagger


### PR DESCRIPTION
Running in apache mod_wsgi: 
- the previous version works well when the api is exposed in the root url "https://myapi.com/" 
- but not when the api is exposed **by apache** in a different path like "https://myhost.com/api/". In this case, the '/api/' prefix is configured by apache, and it is not affected by the url_prefix of get_swagger_blueprint(url_prefix="").

In order to fix both cases, **flask.url_for()** can be used to always get the correct path to the /api-docs endpoint.