### PR TITLE
Use URL_PREFIX to construct server URLs

### DIFF
--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -44,6 +44,8 @@ def info():
 
 def servers():
     url = app.config.get(HOST) or "%s://%s" % (_get_scheme(), request.host)
+    if app.config["URL_PREFIX"]:
+        url = url + "/" + app.config["URL_PREFIX"]
     if app.config["API_VERSION"]:
         url = url + "/" + app.config["API_VERSION"]
     return [{"url": url}]


### PR DESCRIPTION
eve-swagger ignores URL_PREFIX, so when it is set, it generates incorrect URLs
Fixes pyeve/eve-swagger#119