### PR TITLE
Use request.scheme in servers()

### DIFF
--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -17,10 +17,6 @@ from .paths import get_ref_schema
 from .definitions import INFO, HOST
 
 
-def _get_scheme():
-    return "http" if app.auth is None else "https"
-
-
 def info():
     validate_info()
 
@@ -43,7 +39,7 @@ def info():
 
 
 def servers():
-    url = app.config.get(HOST) or "%s://%s" % (_get_scheme(), request.host)
+    url = app.config.get(HOST) or "%s://%s" % (request.scheme, request.host)
     if app.config["API_VERSION"]:
         url = url + "/" + app.config["API_VERSION"]
     return [{"url": url}]


### PR DESCRIPTION
When there is no HOST defined, uses request.scheme in servers()
instead of deciding wether to use https or http based on the
presence of app.auth.

Fixes #123