### PR TITLE
Fix typo in schemas

### DIFF
--- a/eve_swagger/definitions.py
+++ b/eve_swagger/definitions.py
@@ -47,7 +47,7 @@ def definitions():
     }
     definitions["Error"] = error_schema
     # add default meta response eve schema
-    respone_metadata_schema = {
+    response_metadata_schema = {
         "type": "object",
         "properties": {
             "page": {"type": "string"},
@@ -55,9 +55,9 @@ def definitions():
             "max_results": {"type": "integer"},
         },
     }
-    definitions["respone_metadata"] = respone_metadata_schema
+    definitions["response_metadata"] = response_metadata_schema
 
-    respone_links_schema = {
+    response_links_schema = {
         "type": "object",
         "properties": {
             "parent": {
@@ -77,7 +77,7 @@ def definitions():
         },
     }
 
-    definitions["respone_links"] = respone_links_schema
+    definitions["response_links"] = response_links_schema
 
     return definitions
 

--- a/eve_swagger/paths.py
+++ b/eve_swagger/paths.py
@@ -145,11 +145,11 @@ def get_response(rd):
 
     properties = {
         app.config["ITEMS"]: {"type": "array", "items": get_ref_schema(rd)},
-        app.config["META"]: {"$ref": "#/components/schemas/respone_metadata"},
+        app.config["META"]: {"$ref": "#/components/schemas/response_metadata"},
     }
 
     if rd.get("hateoas", app.config["HATEOAS"]):
-        properties[app.config["LINKS"]] = {"$ref": "#/components/schemas/respone_links"}
+        properties[app.config["LINKS"]] = {"$ref": "#/components/schemas/response_links"}
 
     r = OrderedDict(
         [


### PR DESCRIPTION
Replace respone_metadata with response_metadata, and respone_links
with response_links.

Fixes pyeve/eve-swagger#125